### PR TITLE
Added new method 'requestBodyAndHeaders'

### DIFF
--- a/RoutingGrailsPlugin.groovy
+++ b/RoutingGrailsPlugin.groovy
@@ -157,6 +157,9 @@ added with the 'grails create-route route-name' command.
             artifact.metaClass.requestMessage = { endpoint,message ->
                 template.requestBody(endpoint,message)
             }
+            artifact.metaClass.requestMessageAndHeaders = { endpoint, message, headers ->
+                template.requestBodyAndHeaders(endpoint, message, headers)
+            }
         }
     }
 


### PR DESCRIPTION
Added new method 'requestBodyAndHeaders' to artifacts to be able to send headers when using the request/response pattern
