### PR TITLE
camel-spring dependency to runtime mode.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -32,7 +32,7 @@ grails.project.dependency.resolution = {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
 
         build('org.apache.camel:camel-core:2.9.0')
-        build('org.apache.camel:camel-spring:2.9.0') {
+        runtime('org.apache.camel:camel-spring:2.9.0') {
             excludes 'spring-aop', 'spring-beans', 'spring-core', 'spring-expression', 'spring-asm', 'spring-tx', 'spring-context'
         }
         runtime('org.apache.camel:camel-groovy:2.9.0') {


### PR DESCRIPTION
Currently, the dependency 'camel-spring' in BuildConfig.groovy is set in build form, causing it to not run properly when you package in war file. So, I change it to runtime, telling the grails that dependency it's nescessary when I will run the project, such war files, not only in build step.
