### PR TITLE
Add ability to enable MDC logging on Camel Context

### DIFF
--- a/RoutingGrailsPlugin.groovy
+++ b/RoutingGrailsPlugin.groovy
@@ -23,6 +23,7 @@ class RoutingGrailsPlugin {
 	def doWithSpring = {
 		def config = application.config.grails.routing
 		def camelContextId = config?.camelContextId ?: 'camelContext'
+        def useMDCLogging = config?.useMDCLogging ?: false
 		def routeClasses = application.routeClasses
 
 		initializeRouteBuilderHelpers()
@@ -44,7 +45,7 @@ class RoutingGrailsPlugin {
 
 		xmlns camel:'http://camel.apache.org/schema/spring'
 
-		camel.camelContext(id: camelContextId) {
+		camel.camelContext(id: camelContextId, useMDCLogging: useMDCLogging) {
 			def threadPoolProfileConfig = config?.defaultThreadPoolProfile
 
 			camel.threadPoolProfile(


### PR DESCRIPTION
Camel supports MDC logging since 2.7.  The grails-routing plugin should provide a simple way for the user to enable this.
