### PR TITLE
Configurable dynamic methods

### DIFF
--- a/RoutingGrailsPlugin.groovy
+++ b/RoutingGrailsPlugin.groovy
@@ -81,18 +81,19 @@ class RoutingGrailsPlugin {
 	}
 
 	def doWithDynamicMethods = { ctx ->
-		def template = ctx.getBean('producerTemplate')
+		def config = application.config.grails.routing
+		if (!config?.disableDynamicMethods) {
+			def template = ctx.getBean('producerTemplate')
 
-		addDynamicMethods(application.controllerClasses, template)
-		addDynamicMethods(application.serviceClasses, template)
+			addDynamicMethods(application.controllerClasses, template)
+			addDynamicMethods(application.serviceClasses, template)
 
-		if (isQuartzPluginInstalled(application)) {
-			addDynamicMethods(application.taskClasses, template)
+			if (isQuartzPluginInstalled(application)) {
+				addDynamicMethods(application.taskClasses, template)
+			}
 		}
 
 		// otherwise we autostart camelContext here
-		def config = application.config.grails.routing
-		
 		if (config.grails.routing.autoStartup ?: true) {
                         def camelContextId = config.camelContextId ?: 'camelContext'
 			application.mainContext.getBean(camelContextId).start()
@@ -105,12 +106,15 @@ class RoutingGrailsPlugin {
 	]
 
 	def onChange = { event ->
-		def artifactName = "${event.source.name}"
+		def config = application.config.grails.routing
+		if (!config?.disableDynamicMethods) {
+			def artifactName = "${event.source.name}"
 
-		if (artifactName.endsWith('Controller') || artifactName.endsWith('Service')) {
-			def artifactType = (artifactName.endsWith('Controller')) ? 'controller' : 'service'
-			def grailsClass = application."${artifactType}Classes".find { it.fullName == artifactName }
-			addDynamicMethods([grailsClass], event.ctx.getBean('producerTemplate'))
+			if (artifactName.endsWith('Controller') || artifactName.endsWith('Service')) {
+				def artifactType = (artifactName.endsWith('Controller')) ? 'controller' : 'service'
+				def grailsClass = application."${artifactType}Classes".find { it.fullName == artifactName }
+				addDynamicMethods([grailsClass], event.ctx.getBean('producerTemplate'))
+			}
 		}
 	}
 

--- a/grails-app/services/org/grails/plugins/routing/CamelMessageService.groovy
+++ b/grails-app/services/org/grails/plugins/routing/CamelMessageService.groovy
@@ -1,0 +1,39 @@
+package org.grails.plugins.routing
+
+import javax.activation.DataHandler
+import org.apache.camel.Exchange
+import org.apache.camel.Message
+import org.apache.camel.Processor
+
+class CamelMessageService {
+    static transactional = false
+
+    def producerTemplate
+
+    def sendMessage(endpoint,message) {
+        producerTemplate.sendBody(endpoint,message)
+    }
+
+    def sendMessageAndHeaders(endpoint, message, headers) {
+        producerTemplate.sendBodyAndHeaders(endpoint,message,headers)
+    }
+
+    def sendMessageAndHeadersAndAttachments(endpoint, message, headers, Map<String, DataHandler> attachments) {
+        producerTemplate.send( endpoint, { Exchange exchange ->
+            Message msg = exchange.in;
+            msg.setBody(message)
+            msg.setHeaders(headers)
+            attachments.each {
+                msg.addAttachment(it.key, it.value)
+            }
+        } as Processor)
+    }
+
+    def requestMessage(endpoint,message) {
+        producerTemplate.requestBody(endpoint,message)
+    }
+
+    def requestMessageAndHeaders(endpoint, message, headers) {
+        producerTemplate.requestBodyAndHeaders(endpoint, message, headers)
+    }
+}


### PR DESCRIPTION
Created a CamelMessageService for use instead of invasively setting
generic metaclass property names like "sendMessage" on all Controllers/Services/Jobs.
sendMessage is likely to clash with existing methods.

Injected dynamic method names can be disabled by using the config option:
grails.routing.disableDynamicMethods = true
