### PR TITLE
fixed autoStartup due to changes in camel version 2.14.0

### DIFF
--- a/RoutingGrailsPlugin.groovy
+++ b/RoutingGrailsPlugin.groovy
@@ -115,7 +115,7 @@ class RoutingGrailsPlugin {
 
 		if (config.autoStartup != false) {
                         def camelContextId = config.camelContextId ?: 'camelContext'
-			application.mainContext.getBean(camelContextId).start()
+			application.mainContext.getBean(camelContextId).startAllRoutes()
 		}
 	}
 


### PR DESCRIPTION
http://camel.apache.org/camel-2140-release.html
..
Changes that may affect end users
..
- Setting autoStartup to false, and starting a CamelContext the 2nd time now does not start the routes, instead use the new startAllRoutes method on CamelContext to start all the routes.
..